### PR TITLE
FIX - use anchor element href rather than innerHTML

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -2,7 +2,8 @@
     $.entwine('copybutton', function($) {
         $('.field.urlsegment .btn.copy').entwine({
             onclick: function() {
-                var url = document.getElementsByClassName('URL-link')[0].innerHTML;
+                var url = document.getElementsByClassName('URL-link')[0].href;
+                url = url.replace('?stage=Stage', '');
                 navigator.clipboard.writeText(url)
                     .then(() => {
                         console.log("Text copied to clipboard...")


### PR DESCRIPTION
This is a fix for #1 , using href rather than innerHTML and removing the ?stage=Stage string.