### PR TITLE
remove button if navigator.clipboard is not available

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -1,6 +1,12 @@
 (function($){
     $.entwine('copybutton', function($) {
         $('.field.urlsegment .btn.copy').entwine({
+            onmatch: function () {
+                if (navigator.clipboard == undefined) {
+                    $('.field.urlsegment .btn.copy').remove();
+                }
+                this._super();
+            },
             onclick: function() {
                 var url = document.getElementsByClassName('URL-link')[0].href;
                 url = url.replace('?stage=Stage', '');


### PR DESCRIPTION
e.g. on insecure connections (local development etc) or if the browser doesn't support it. 